### PR TITLE
Potential fix for code scanning alert no. 11: Unvalidated dynamic method call

### DIFF
--- a/ui/lib/src/socket.ts
+++ b/ui/lib/src/socket.ts
@@ -302,7 +302,10 @@ class WsSocket {
       default:
         // return true in a receive handler to prevent pubsub and events
         if (!(this.settings.receive && this.settings.receive(m.t, m.d))) {
-          const sentAsEvent = this.settings.events[m.t] && this.settings.events[m.t](m.d || null, m);
+          const sentAsEvent =
+            this.settings.events.hasOwnProperty(m.t) &&
+            typeof this.settings.events[m.t] === 'function' &&
+            this.settings.events[m.t](m.d || null, m);
           if (!sentAsEvent) pubsub.emit(('socket.in.' + m.t) as PubsubEvent, m.d, m);
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/lila/security/code-scanning/11](https://github.com/codeallthethingsbreak/lila/security/code-scanning/11)

To fix the issue, we need to validate the dynamic method lookup `this.settings.events[m.t]` before invoking it. Specifically:
1. Check if `m.t` is a valid key in `this.settings.events` using `hasOwnProperty`.
2. Ensure that the value of `this.settings.events[m.t]` is a function before invoking it.

This fix ensures that only valid and callable methods are invoked, preventing runtime exceptions and mitigating the risk of malicious input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
